### PR TITLE
Allow repairers & builders to target second energy source

### DIFF
--- a/src/components/creeps/builder.ts
+++ b/src/components/creeps/builder.ts
@@ -5,6 +5,7 @@ export interface IBuilder {
 
   targetConstructionSite: ConstructionSite;
   energyStation: Spawn | Structure;
+  targetSource: Source;
 
   hasEmptyBag(): boolean;
   isBagFull(): boolean;
@@ -21,12 +22,14 @@ export class Builder extends CreepAction implements IBuilder, ICreepAction {
 
   public targetConstructionSite: ConstructionSite = null;
   public energyStation: Spawn | Structure = null;
+  public targetSource: Source = null;
 
   public setCreep(creep: Creep) {
     super.setCreep(creep);
 
     this.targetConstructionSite = <ConstructionSite>Game.getObjectById(this.creep.memory.target_construction_site_id);
     this.energyStation = <Spawn | Structure>Game.getObjectById(this.creep.memory.target_energy_station_id);
+    this.targetSource = <Source>Game.getObjectById(this.creep.memory.target_source_id);
   }
 
   public hasEmptyBag(): boolean {
@@ -51,6 +54,16 @@ export class Builder extends CreepAction implements IBuilder, ICreepAction {
     }
   }
 
+  public tryHarvest(): number {
+    return this.creep.harvest(this.targetSource);
+  }
+
+  public moveToHarvest(): void {
+    if (this.tryHarvest() == ERR_NOT_IN_RANGE) {
+      this.moveTo(this.targetSource);
+    }
+  }
+
   public tryBuild(): number {
     return this.creep.build(this.targetConstructionSite);
   }
@@ -70,7 +83,11 @@ export class Builder extends CreepAction implements IBuilder, ICreepAction {
     }
 
     if (this.hasEmptyBag()) {
-      this.moveToAskEnergy();
+      if (this.creep.memory.target_source_id) {
+        this.moveToHarvest();
+      } else {
+        this.moveToAskEnergy();
+      }
     } else {
       this.moveToBuild();
     }

--- a/src/components/creeps/builder.ts
+++ b/src/components/creeps/builder.ts
@@ -84,14 +84,14 @@ export class Builder extends CreepAction implements IBuilder, ICreepAction {
 
     if (this.needsRenew()) {
       this.moveToRenew();
-    } else if (this.hasEmptyBag()) {
+    } else if (this.creep.memory.building) {
+      this.moveToBuild();
+    } else {
       if (this.creep.memory.target_source_id) {
         this.moveToHarvest();
       } else {
         this.moveToAskEnergy();
       }
-    } else {
-      this.moveToBuild();
     }
 
     return true;

--- a/src/components/creeps/builder.ts
+++ b/src/components/creeps/builder.ts
@@ -82,7 +82,9 @@ export class Builder extends CreepAction implements IBuilder, ICreepAction {
       this.creep.memory.building = true;
     }
 
-    if (this.hasEmptyBag()) {
+    if (this.needsRenew()) {
+      this.moveToRenew();
+    } else if (this.hasEmptyBag()) {
       if (this.creep.memory.target_source_id) {
         this.moveToHarvest();
       } else {

--- a/src/components/creeps/creepManager.ts
+++ b/src/components/creeps/creepManager.ts
@@ -106,6 +106,10 @@ export namespace CreepManager {
   }
 
   export function createBuilder(): number | string {
+    let targetSource_id: string = SourceManager.sourceCount > 1 ?
+      SourceManager.sources[1].id : null;
+    let energyStation_id: string = targetSource_id == null ?
+      SpawnManager.getFirstSpawn().id : null;
     let constructionSite_id: string = ConstructionSiteManager.getConstructionSite() ?
       ConstructionSiteManager.getConstructionSite().id : null;
 
@@ -114,7 +118,8 @@ export namespace CreepManager {
     let properties: any = {
       role: 'builder',
       target_construction_site_id: constructionSite_id,
-      target_energy_station_id: SpawnManager.getFirstSpawn().id,
+      target_source_id: targetSource_id,
+      target_energy_station_id: energyStation_id,
       renew_station_id: SpawnManager.getFirstSpawn().id,
       building: false
     }
@@ -132,9 +137,13 @@ export namespace CreepManager {
   }
 
   export function createRepairer(): number | string {
-    let energyStation_id: string = StructureManager.getStorageObject() ?
-      StructureManager.getStorageObject().id :
-      SpawnManager.getFirstSpawn().id;
+    let targetSource_id: string = SourceManager.sourceCount > 1 ?
+      SourceManager.sources[1].id : null;
+    let energyStation_id: string = targetSource_id == null ?
+      SpawnManager.getFirstSpawn().id : null;
+    // let energyStation_id: string = StructureManager.getStorageObject() ?
+    //   StructureManager.getStorageObject().id :
+    //   SpawnManager.getFirstSpawn().id;
     let toRepair_id: string = StructureManager.getStructuresToRepair() ?
       StructureManager.getStructuresToRepair().id : null;
 
@@ -143,6 +152,7 @@ export namespace CreepManager {
     let properties: any = {
       role: 'repairer',
       target_repair_site_id: StructureManager.getStructuresToRepair().id,
+      target_source_id: targetSource_id,
       target_energy_station_id: energyStation_id,
       renew_station_id: SpawnManager.getFirstSpawn().id,
       repairing: false

--- a/src/components/creeps/repairer.ts
+++ b/src/components/creeps/repairer.ts
@@ -85,7 +85,9 @@ export class Repairer extends CreepAction implements IRepairer, ICreepAction {
       this.creep.memory.repairing = true;
     }
 
-    if (this.creep.memory.repairing) {
+    if (this.needsRenew()) {
+      this.moveToRenew();
+    } else if (this.creep.memory.repairing) {
       this.moveToRepair();
     } else {
       if (this.creep.memory.target_source_id) {

--- a/src/components/creeps/repairer.ts
+++ b/src/components/creeps/repairer.ts
@@ -5,6 +5,7 @@ export interface IRepairer {
 
   targetStructure: Structure;
   energyStation: Spawn | Structure;
+  targetSource: Source;
   _minHitsBeforeNeedsRepair: number;
 
   hasEmptyBag(): boolean;
@@ -22,6 +23,7 @@ export class Repairer extends CreepAction implements IRepairer, ICreepAction {
 
   public targetStructure: Structure = null;
   public energyStation: Spawn | Structure = null;
+  public targetSource: Source = null;
 
   public _minHitsBeforeNeedsRepair: number = Config.DEFAULT_MIN_HITS_BEFORE_NEEDS_REPAIR;
 
@@ -30,6 +32,7 @@ export class Repairer extends CreepAction implements IRepairer, ICreepAction {
 
     this.targetStructure = <Structure>Game.getObjectById(this.creep.memory.target_repair_site_id);
     this.energyStation = <Spawn | Structure>Game.getObjectById(this.creep.memory.target_energy_station_id);
+    this.targetSource = <Source>Game.getObjectById(this.creep.memory.target_source_id);
   }
 
   public hasEmptyBag(): boolean {
@@ -54,6 +57,16 @@ export class Repairer extends CreepAction implements IRepairer, ICreepAction {
     }
   }
 
+  public tryHarvest(): number {
+    return this.creep.harvest(this.targetSource);
+  }
+
+  public moveToHarvest(): void {
+    if (this.tryHarvest() == ERR_NOT_IN_RANGE) {
+      this.moveTo(this.targetSource);
+    }
+  }
+
   public tryRepair(): number {
     return this.creep.repair(this.targetStructure);
   }
@@ -75,7 +88,11 @@ export class Repairer extends CreepAction implements IRepairer, ICreepAction {
     if (this.creep.memory.repairing) {
       this.moveToRepair();
     } else {
-      this.moveToAskEnergy();
+      if (this.creep.memory.target_source_id) {
+        this.moveToHarvest();
+      } else {
+        this.moveToAskEnergy();
+      }
     }
 
     return true;

--- a/src/components/creeps/upgrader.ts
+++ b/src/components/creeps/upgrader.ts
@@ -82,7 +82,9 @@ export class Upgrader extends CreepAction implements IUpgrader, ICreepAction {
       this.creep.memory.upgrading = true;
     }
 
-    if (this.creep.memory.upgrading) {
+    if (this.needsRenew()) {
+      this.moveToRenew();
+    } else if (this.creep.memory.upgrading) {
       this.moveToUpgrade();
     } else {
       if (this.creep.memory.target_source_id) {

--- a/src/shared/memoryManager.ts
+++ b/src/shared/memoryManager.ts
@@ -112,7 +112,14 @@ export namespace MemoryManager {
           console.log('[MemoryManager] Updating outdated energy station ID for ' + creep.name);
         }
 
-        creep.memory.target_energy_station_id = SpawnManager.getFirstSpawn() ? SpawnManager.getFirstSpawn().id : null;
+        // we'll find the second energy source on the list first to avoid congestion at spawn
+        creep.memory.target_source_id = SourceManager.sourceCount > 1 ?
+          SourceManager.sources[1].id : null;
+
+        creep.memory.target_energy_station_id = creep.memory.target_source_id == null ?
+          SpawnManager.getFirstSpawn().id : null;
+
+        // creep.memory.target_energy_station_id = SpawnManager.getFirstSpawn() ? SpawnManager.getFirstSpawn().id : null;
       }
 
     });
@@ -143,7 +150,14 @@ export namespace MemoryManager {
           console.log('[MemoryManager] Updating outdated target energy station ID for ' + creep.name);
         }
 
-        creep.memory.target_energy_station_id = SpawnManager.getFirstSpawn() ? SpawnManager.getFirstSpawn().id : null;
+        // we'll find the second energy source on the list first to avoid congestion at spawn
+        creep.memory.target_source_id = SourceManager.sourceCount > 1 ?
+          SourceManager.sources[1].id : null;
+
+        creep.memory.target_energy_station_id = creep.memory.target_source_id == null ?
+          SpawnManager.getFirstSpawn().id : null;
+
+        // creep.memory.target_energy_station_id = SpawnManager.getFirstSpawn() ? SpawnManager.getFirstSpawn().id : null;
       }
 
     });


### PR DESCRIPTION
The current state of builders and repairers is that they all just default to spawn always, and never target any container when they're full. This causes spawn to be easily depleted of energy.

A better, load-balanced temporary solution at the moment is to allow them to target a second energy source in the room, if available.

Until we have a properly-working `ConstructionSiteManager.getConstructionSite()` method, we'll use this instead.
