### PR TITLE
Go to a designated flag when creeps are doing nothing

### DIFF
--- a/src/components/creeps/builder.ts
+++ b/src/components/creeps/builder.ts
@@ -1,5 +1,6 @@
 import { Config } from './../../config/config';
 import { ICreepAction, CreepAction } from './creepAction';
+import { FlagManager } from '../flags/flagManager';
 
 export interface IBuilder {
 
@@ -86,9 +87,17 @@ export class Builder extends CreepAction implements IBuilder, ICreepAction {
       this.moveToBuild();
     } else {
       if (this.creep.memory.target_source_id) {
-        this.moveToHarvest();
+        if (!this.isBagFull()) {
+          this.moveToHarvest();
+        } else {
+          this.moveTo(FlagManager.getFlag('BuildersPost'));
+        }
       } else {
-        this.moveToAskEnergy();
+        if (!this.isBagFull()) {
+          this.moveToAskEnergy();
+        } else {
+          this.moveTo(FlagManager.getFlag('BuildersPost'));
+        }
       }
     }
 

--- a/src/components/creeps/builder.ts
+++ b/src/components/creeps/builder.ts
@@ -76,7 +76,7 @@ export class Builder extends CreepAction implements IBuilder, ICreepAction {
   }
 
   public action(): boolean {
-    if (this.creep.memory.building && this.hasEmptyBag()) {
+    if ((this.creep.memory.building && this.hasEmptyBag()) || this.targetConstructionSite === null) {
       this.creep.memory.building = false;
     }
     if (!this.creep.memory.building && this.isBagFull()) {

--- a/src/components/creeps/repairer.ts
+++ b/src/components/creeps/repairer.ts
@@ -79,7 +79,7 @@ export class Repairer extends CreepAction implements IRepairer, ICreepAction {
   }
 
   public action(): boolean {
-    if (this.creep.memory.repairing && this.hasEmptyBag()) {
+    if ((this.creep.memory.repairing && this.hasEmptyBag()) || this.targetStructure === null) {
       this.creep.memory.repairing = false;
     }
     if (!this.creep.memory.repairing && this.isBagFull()) {

--- a/src/components/creeps/repairer.ts
+++ b/src/components/creeps/repairer.ts
@@ -1,5 +1,6 @@
 import { Config } from './../../config/config';
 import { ICreepAction, CreepAction } from './creepAction';
+import { FlagManager } from '../flags/flagManager';
 
 export interface IRepairer {
 
@@ -89,9 +90,17 @@ export class Repairer extends CreepAction implements IRepairer, ICreepAction {
       this.moveToRepair();
     } else {
       if (this.creep.memory.target_source_id) {
-        this.moveToHarvest();
+        if (!this.isBagFull()) {
+          this.moveToHarvest();
+        } else {
+          this.moveTo(FlagManager.getFlag('RepairersPost'));
+        }
       } else {
-        this.moveToAskEnergy();
+        if (!this.isBagFull()) {
+          this.moveToAskEnergy();
+        } else {
+          this.moveTo(FlagManager.getFlag('RepairersPost'));
+        }
       }
     }
 

--- a/src/components/creeps/wallRepairer.ts
+++ b/src/components/creeps/wallRepairer.ts
@@ -79,7 +79,7 @@ export class WallRepairer extends CreepAction implements IWallRepairer, ICreepAc
   }
 
   public action(): boolean {
-    if (this.creep.memory.repairing && this.hasEmptyBag()) {
+    if ((this.creep.memory.repairing && this.hasEmptyBag()) || this.targetStructure === null) {
       this.creep.memory.repairing = false;
     }
     if (!this.creep.memory.repairing && this.isBagFull()) {

--- a/src/components/creeps/wallRepairer.ts
+++ b/src/components/creeps/wallRepairer.ts
@@ -1,5 +1,6 @@
 import { Config } from './../../config/config';
 import { ICreepAction, CreepAction } from './creepAction';
+import { FlagManager } from '../flags/flagManager';
 
 interface IWallRepairer {
 
@@ -89,9 +90,17 @@ export class WallRepairer extends CreepAction implements IWallRepairer, ICreepAc
       this.moveToRepair();
     } else {
       if (this.creep.memory.target_source_id) {
-        this.moveToHarvest();
+        if (!this.isBagFull()) {
+          this.moveToHarvest();
+        } else {
+          this.moveTo(FlagManager.getFlag('RepairersPost'));
+        }
       } else {
-        this.moveToAskEnergy();
+        if (!this.isBagFull()) {
+          this.moveToAskEnergy();
+        } else {
+          this.moveTo(FlagManager.getFlag('RepairersPost'));
+        }
       }
     }
 

--- a/src/components/flags/flagManager.ts
+++ b/src/components/flags/flagManager.ts
@@ -22,6 +22,10 @@ export namespace FlagManager {
     return this.flags[this.flagNames[0]];
   }
 
+  export function getFlag(name: string): Flag {
+    return this.flags[name];
+  }
+
   function _loadFlagNames(): void {
     for (let name in flags) {
       if (flags.hasOwnProperty(name)) {


### PR DESCRIPTION
This applies to `Builder`, `Repairer`, and `WallRepairer` creeps. (Fixes #11)
